### PR TITLE
Update manifest.js

### DIFF
--- a/transform/babel-plugin-fbt/bin/manifest.js
+++ b/transform/babel-plugin-fbt/bin/manifest.js
@@ -73,7 +73,7 @@ const lines = newlined =>
 
 // Find enum files
 const enumFiles = lines(
-  execSync("find -type f -iname '*$FbtEnum.js'", {
+  execSync("find . -type f -iname '*$FbtEnum.js'", {
     cwd: argv.src,
   }),
 );


### PR DESCRIPTION
While doing the getting started, I got:

![image](https://user-images.githubusercontent.com/13785185/50653919-6fad2600-0f8b-11e9-966a-b3f9e76b6d9a.png)

According to https://stackoverflow.com/questions/25840713/illegal-option-error-when-using-find-on-macos, we should not forget the path. While gnu find is permissive to path ommission, mac osx is POSIX compliant http://pubs.opengroup.org/onlinepubs/9699919799/utilities/find.html