### PR TITLE
Avoiding using a symbolic link for node_modules

### DIFF
--- a/demo-app/node_modules
+++ b/demo-app/node_modules
@@ -1,1 +1,0 @@
-../node_modules

--- a/demo-app/package.json
+++ b/demo-app/package.json
@@ -5,12 +5,12 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "build": "babel-node  ../node_modules/webpack/bin/webpack",
+    "build": "babel-node ../node_modules/webpack/bin/webpack",
     "manifest": "babel-node ../transform/babel-plugin-fbt/bin/manifest --src src",
     "collect-fbts": "babel-node ../transform/babel-plugin-fbt/bin/collectFBT --json-input < .src_manifest.json > source_strings.json",
     "translate-fbts": "babel-node ../transform/babel-plugin-fbt/bin/translate.js --jenkins < ./translation_input.json > src/translatedFbts.json",
     "clean-fbts": "rm .enum_manifest.json .src_manifest.json source_strings.json src/translatedFbts.json 2&> /dev/null || exit 0",
-    "start": "babel-node  ../node_modules/webpack-dev-server/bin/webpack-dev-server --open",
+    "start": "babel-node ../node_modules/webpack-dev-server/bin/webpack-dev-server --open",
     "test": "babel-node ../node_modules/jest/bin/jest --config ./jest.config.json"
   },
   "devDependencies": {


### PR DESCRIPTION
This will avoid yarn to be confused on Windows.

Tested on Cygwin and the test web page loaded normally:

```
davidhsc@DAVIDHSC-Y12 ~/dev/source/facebookincubator/fbt
$ yarn install
yarn install v1.12.3
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
Done in 52.70s.

davidhsc@DAVIDHSC-Y12 ~/dev/source/facebookincubator/fbt
$ cd demo-app/

davidhsc@DAVIDHSC-Y12 ~/dev/source/facebookincubator/fbt/demo-app
$ yarn install
yarn install v1.12.3
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.2.4: The platform "win32" is incompatible with this module.
info "fsevents@1.2.4" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
[4/4] Building fresh packages...
Done in 85.08s.

davidhsc@DAVIDHSC-Y12 ~/dev/source/facebookincubator/fbt/demo-app
$ yarn manifest
yarn run v1.12.3
$ babel-node ../transform/babel-plugin-fbt/bin/manifest --src src
Done in 2.25s.

davidhsc@DAVIDHSC-Y12 ~/dev/source/facebookincubator/fbt/demo-app
$ yarn collect-fbts
yarn run v1.12.3
$ babel-node ../transform/babel-plugin-fbt/bin/collectFBT --json-input < .src_manifest.json > source_strings.json
Done in 1.65s.

davidhsc@DAVIDHSC-Y12 ~/dev/source/facebookincubator/fbt/demo-app
$ yarn translate-fbts
yarn run v1.12.3
$ babel-node ../transform/babel-plugin-fbt/bin/translate.js --jenkins < ./translation_input.json > src/translatedFbts.json
Done in 1.34s.

davidhsc@DAVIDHSC-Y12 ~/dev/source/facebookincubator/fbt/demo-app
$ yarn start
yarn run v1.12.3
$ babel-node ../node_modules/webpack-dev-server/bin/webpack-dev-server --open
i ｢wds｣: Project is running at http://localhost:8080/
i ｢wds｣: webpack output is served from /
i ｢wds｣: Content not from webpack is served from C:\Users\davidhsc\dev\source\facebookincubator\fbt\demo-app\src
i ｢wdm｣: wait until bundle finished: /
[BABEL] Note: The code generator has deoptimised the styling of C:\Users\davidhsc\dev\source\facebookincubator\fbt\node_modules\react-dom\cjs\react-dom.development.js as it exceeds the max of 500KB.
i ｢wdm｣: Hash: 4ce112e75c7bad18dfba
Version: webpack 4.28.1
Time: 8391ms
Built at: 01/03/2019 6:05:09 PM
     Asset       Size  Chunks             Chunk Names
index.html  288 bytes          [emitted]
   main.js   1.28 MiB    main  [emitted]  main
Entrypoint main = main.js
[0] multi ../node_modules/webpack-dev-server/client?http://localhost:8080 ./src/root.js 40 bytes {main} [built]
[../node_modules/loglevel/lib/loglevel.js] 6.84 KiB {main} [built]
[../node_modules/normalize.css/normalize.css] 1.01 KiB {main} [built]
[../node_modules/react-dom/index.js] 1.32 KiB {main} [built]
[../node_modules/react/index.js] 189 bytes {main} [built]
[../node_modules/strip-ansi/index.js] 162 bytes {main} [built]
[../node_modules/url/url.js] 22.2 KiB {main} [built]
[../node_modules/webpack-dev-server/client/index.js?http://localhost:8080] ../node_modules/webpack-dev-server/client?http://localhost:8080 7.79 KiB {main} [built]
[../node_modules/webpack-dev-server/client/overlay.js] 3.58 KiB {main} [built]
[../node_modules/webpack-dev-server/client/socket.js] 1.05 KiB {main} [built]
[../node_modules/webpack/hot sync ^\.\/log$] ../node_modules/webpack/hot sync nonrecursive ^\.\/log$ 170 bytes {main} [built]
[../node_modules/webpack/hot/emitter.js] 75 bytes {main} [built]
[./src/css/root.css] 1.07 KiB {main} [built]
[./src/example/Example.react.js] 14.1 KiB {main} [built]
[./src/root.js] 414 bytes {main} [built]
    + 113 hidden modules
Child html-webpack-plugin for "index.html":
     1 asset
    Entrypoint undefined = index.html
    [../node_modules/html-webpack-plugin/lib/loader.js!./src/root.html] 453 bytes {0} [built]
    [../node_modules/lodash/lodash.js] 527 KiB {0} [built]
    [../node_modules/webpack/buildin/global.js] 475 bytes {0} [built]
    [../node_modules/webpack/buildin/module.js] 546 bytes {0} [built]
i ｢wdm｣: Compiled successfully.
```