### PR TITLE
Fix footer docs links on webpage (fixes #28)

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -33,13 +33,13 @@ class Footer extends React.Component {
           </a>
           <div>
             <h5>Docs</h5>
-            <a href={this.docUrl('getting_started', this.props.language)}>
+            <a href={this.docUrl('getting_started')}>
               Getting Started
             </a>
             <a href={this.pageUrl('help', this.props.language)}>
               Help
             </a>
-            <a href={this.docUrl('api_intro', this.props.language)}>
+            <a href={this.docUrl('api_intro')}>
               API Reference
             </a>
           </div>


### PR DESCRIPTION
On footer all the links are using the docUrl method that is adding the language on the url:

/fbt/docs/en/api_intro
/fbt/docs/en/getting_started
However, these links are not correct. Getting an 404 error.

Although maybe in the future will be support for many languages, I think is better to change this invalid links for the valid links right now.