### PR TITLE
Use JSON syntax in docs & Fix typo in manifest.js

### DIFF
--- a/demo-app/src/example/Example.react.js
+++ b/demo-app/src/example/Example.react.js
@@ -59,7 +59,7 @@ const LOCALES = Object.freeze({
 
 type Locale = $Keys<typeof LOCALES>;
 type Variation = $Values<typeof IntlVariations>;
-type SharedObj = $Keys<typeof ExamplEnum>;
+type SharedObj = $Keys<typeof ExampleEnum>;
 type PronounGender = $Keys<typeof GenderConst>;
 
 type Props = $ReadOnly<{||}>;

--- a/docs/translating.md
+++ b/docs/translating.md
@@ -28,10 +28,10 @@ is a good reference on the "schema" used for the translations.
     "translations": {
       <translation_hash>: {
         "tokens": [<token1>, ..., <tokenN>],
-        "types": [<variationType1>, ..., <variationTypeN>],
+        "types": [<variationType1>, ..., <variationTypeN>]
         "translations": [{
             "translation": <translation1>,
-            "variations": [variationValue1,...,variationValueN],
+            "variations": [variationValue1,...,variationValueN]
           },
           ...,
         ]

--- a/docs/translating.md
+++ b/docs/translating.md
@@ -13,7 +13,7 @@ provided in our [GitHub demo
 app](https://github.com/facebookincubator/fbt/blob/master/demo-app/translation_input.json)
 is a good reference on the "schema" used for the translations.
 
-```js
+```json
 {
   "phrases": [
     "hashToText": {

--- a/docs/translating.md
+++ b/docs/translating.md
@@ -15,23 +15,23 @@ is a good reference on the "schema" used for the translations.
 
 ```js
 {
-  phrases: [
+  "phrases": [
     "hashToText": {
       <text_hash>: <text>,
       ...
     },
-    jsfbt: string|{t:<table>, m:<metadata>}
+    "jsfbt": string|{t:<table>, m:<metadata>}
   ],
   ...
-  translationGroups: [{
-    "fb-locale": "xx_XX"
+  "translationGroups": [{
+    "fb-locale": "xx_XX",
     "translations": {
       <translation_hash>: {
         "tokens": [<token1>, ..., <tokenN>],
         "types": [<variationType1>, ..., <variationTypeN>],
         "translations": [{
-            "translation": <translation1>
-            "variations": [variationValue1,...,variationValueN]
+            "translation": <translation1>,
+            "variations": [variationValue1,...,variationValueN],
           },
           ...,
         ]

--- a/transform/babel-plugin-fbt/bin/manifest.js
+++ b/transform/babel-plugin-fbt/bin/manifest.js
@@ -48,7 +48,7 @@ const argv = optimist
       'processing shared enums)',
   )
   .default('src-manifest', '.src_manifest.json')
-  .describe('src-manifest', 'The path or filename to write the source manfiest')
+  .describe('src-manifest', 'The path or filename to write the source manifest')
   .argv;
 
 if (argv.help) {


### PR DESCRIPTION
1. As for codeblock in `translating.md`, I think we should use json format as demonstration in `demo-app` uses filename 'translation_input.json`(Also added some missing commas).

2. Just small typo in `manifest.js`

