### PR TITLE
Sync getting started in docs with readme

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -8,6 +8,7 @@ Check out our [github](https://github.com/facebookincubator/fbt) repository and 
 The following assumes you have [node](https://nodejs.org) and [yarn](https://yarnpkg.com) installed.
 ```bash
 git clone git@github.com:facebookincubator/fbt.git;
+yarn install
 cd fbt/demo-app;
 yarn install; # pull in dependencies
 yarn manifest; # generate fbt enum manifests and source manifests


### PR DESCRIPTION
If `yarn install` is not run in the root of the project, build in the demo errors out with:

> `Module not found: Error: Can't resolve 'fbt'`.