### PR TITLE
Repair broken URL reference

### DIFF
--- a/transform/babel-plugin-fbt/FbtUtil.js
+++ b/transform/babel-plugin-fbt/FbtUtil.js
@@ -245,7 +245,7 @@ function expandStringConcat(moduleName, t, node) {
   throwAt(
     node,
     `${moduleName} only accepts plain strings with params wrapped in ${moduleName}.param. ` +
-      `See the docs at https://fburl.com/fbt-children for more info. ` +
+      `See the docs at https://facebookincubator.github.io/fbt/ for more info. ` +
       `Expected StringLiteral, TemplateLiteral, or concatenation; got ${
         node.type
       }`,


### PR DESCRIPTION
An error can be displayed in the console pointing to a dead URL.

<img width="1440" alt="Screen Shot 2019-03-23 at 7 54 30 AM" src="https://user-images.githubusercontent.com/273937/54867753-2629d700-4d41-11e9-9183-1c782f0f4d43.png">