### PR TITLE
Fix instructions in "Getting Started"

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -4,16 +4,19 @@ title: Getting Started
 sidebar_label: Getting Started
 ---
 
-Check out our [github](https://github.com/facebookincubator/fbt) repository and run the demo.
-The following assumes you have [node](https://nodejs.org) and [yarn](https://yarnpkg.com) installed.
+Check out our [GitHub](https://github.com/facebookincubator/fbt) repository and run the demo.
+
+The following assumes you have [Node](https://nodejs.org) and [Yarn](https://yarnpkg.com) installed.
+
 ```bash
-git clone git@github.com:facebookincubator/fbt.git;
-yarn install
-cd fbt/demo-app;
-yarn install; # pull in dependencies
-yarn manifest; # generate fbt enum manifests and source manifests
-yarn collect-fbts; # Collect all fbt phrases from source
-yarn translate-fbts; # Generate the translation payloads
-yarn build;
-yarn start; # Checkout your locally running server at localhost:8081
+git clone git@github.com:facebookincubator/fbt.git
+cd fbt
+yarn install # Build the fbt library
+cd demo-app
+yarn install # Install dependencies for demo
+yarn manifest # Generate fbt enum manifests and source manifests
+yarn collect-fbts # Collect all fbt phrases from source
+yarn translate-fbts # Generate the translation payloads
+yarn build
+yarn start # Check out your locally running server at localhost:8081
 ```


### PR DESCRIPTION
Was trying out FBT and was on the "Getting Started" page and found that the instructions were not quite correct. Doing `yarn install` immediately after cloning isn't right as the user is not yet within the cloned repo. I updated the steps and managed to get the demo app running.