### PR TITLE
Implementing FbtTranslations.getTranslatedPayload to enable fbt for React Native on Android

### DIFF
--- a/live-demo-app/src/example/Example$FbtEnum.js
+++ b/live-demo-app/src/example/Example$FbtEnum.js
@@ -1,5 +1,6 @@
 /**
  * Copyright 2004-present Facebook. All Rights Reserved.
+ * @noflow
  */
 const Example$FbtEnum = {
   LINK: 'link',

--- a/runtime/nonfb/FbtI18nNativeAssets.js
+++ b/runtime/nonfb/FbtI18nNativeAssets.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ * Exposes a NativeModule for fetching translations from Android OS.
+ *
+ * @emails oncall+internationalization
+ * @flow
+ * @format
+ */
+
+import {NativeModules} from 'react-native';
+module.exports = NativeModules.FBCi18nAssets;

--- a/runtime/nonfb/FbtTranslations.js
+++ b/runtime/nonfb/FbtTranslations.js
@@ -10,38 +10,51 @@
 
 'use strict';
 
-const IntlViewerContext = require('IntlViewerContext');
+const FbtI18nAssets = require("./FbtI18nNativeAssets");
 
-let _translatedFbts = null;
+let _translatedFbts: {[hashKey: string]: string} = {};
 
 const FbtTranslations = {
   getTranslatedPayload(
     hashKey: ?string,
-    enumHashKey: $FlowFixMe,
-    args: Array<$FlowFixMe>,
+    enumHashKey: ?Object,
+    args: Array<any>,
     _table: string | Object,
-  ): $FlowFixMe {
-    const table = _translatedFbts && _translatedFbts[IntlViewerContext.locale];
-    if (__DEV__) {
-      if (!table) {
-        console.warn('Translations have not been provided');
-      }
-    }
-
-    if (!table || !table[hashKey]) {
+  ): ?Object {
+    if (FbtI18nAssets === null) {
       return null;
     }
-    return {
-      table: table[hashKey],
-      args: args,
-    };
+
+    if (hashKey !== null) {
+      let translatedPayload;
+      if (args == null || args.length === 0) {
+        // Only caches translations for simple strings with no variations
+        if (_translatedFbts.hasOwnProperty(hashKey)) {
+          translatedPayload = _translatedFbts[hashKey];
+        } else {
+          translatedPayload = FbtI18nAssets.getString(hashKey);
+          _translatedFbts[hashKey] = translatedPayload;
+        }
+      } else {
+        translatedPayload = FbtI18nAssets.getString(hashKey);
+        if (translatedPayload) {
+          translatedPayload = JSON.parse(translatedPayload);
+        }
+      }
+
+      return translatedPayload != null && translatedPayload !== ''
+        ? {table: translatedPayload, args}
+        : null;
+    }
+
+    return null;
   },
 
-  isComponentScript() {
+  isComponentScript(): boolean {
     return false;
   },
 
-  registerTranslations(translations) {
+  registerTranslations(translations: {[hashKey: string]: string}) {
     _translatedFbts = translations;
   },
 };


### PR DESCRIPTION
- Created `runtime/nonfb/FbtI18nNativeAssets.js` to load a NativeModule that reads translations files from the Android OS depending on the device's locale. NativeModule not provided, could be added to this project in a later pull request.

- Implemented `runtime/nonfb/FbtTranslations.js` to get strings from the NativeModule based on the fbt hash. If the NativeModule is not available, null is returned.
