### PR TITLE
New arg split-by-locale-to added to translate.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ demo-app/.enum_manifest.json
 demo-app/.source_strings.json
 demo-app/.src_manifest.json
 demo-app/output
+demo-app/src/translatedFbts
 demo-app/src/translatedFbts.json
 demo-app/yarn-error.log
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,5 +23,7 @@ We haven't had the best track record of code/feature changes before this date, b
 
 ### babel-plugin-fbt-runtime versions
 
+- Next MINOR version
+  - #73 New arg `output-dir` added to the translate script. The output translation files will be split by locale.
 - 0.9.4:
   - [250207c](https://github.com/facebookincubator/fbt/commit/250207c) Update peer dependencies for babel-plugin-fbt.

--- a/demo-app/package.json
+++ b/demo-app/package.json
@@ -13,6 +13,7 @@
     "test-collect-fbts": "babel-node ../transform/babel-plugin-fbt/bin/collectFBT --plugins @babel/plugin-syntax-flow --pretty --manifest < .src_manifest.json > .test_source_strings.json",
     "translate-fbts": "babel-node ../transform/babel-plugin-fbt/bin/translate.js --translations translations/*.json --jenkins > src/translatedFbts.json",
     "translate-fbts-single-file": "babel-node ../transform/babel-plugin-fbt/bin/translate.js --jenkins --stdin < translation_input.json > src/translatedFbts.json",
+    "test-translate-fbts-into-output-dir": "babel-node ../transform/babel-plugin-fbt/bin/translate.js --translations translations/*.json --jenkins --output-dir src/translatedFbts",
     "clean-fbts": "rm .enum_manifest.json .src_manifest.json .source_strings.json src/translatedFbts.json 2&> /dev/null || exit 0",
     "start": "babel-node ../node_modules/webpack-dev-server/bin/webpack-dev-server --open",
     "test": "babel-node ../node_modules/jest/bin/jest --config ./jest.config.json"

--- a/transform/babel-plugin-fbt/bin/translate.js
+++ b/transform/babel-plugin-fbt/bin/translate.js
@@ -77,7 +77,7 @@
  *
  */
 'use strict';
- 
+
 const {objMap} = require('../FbtUtil');
 const {FbtSite} = require('../translate/FbtSite.js');
 const TranslationBuilder = require('../translate/TranslationBuilder');
@@ -95,7 +95,7 @@ const args = {
   SRC: 'source-strings',
   STDIN: 'stdin',
   TRANSLATIONS: 'translations',
-  SPLIT_BY_LOCALE_TO: 'split-by-locale-to',
+  OUTPUT_DIR: 'output-dir',
 };
 
 const argv = yargs
@@ -143,10 +143,11 @@ const argv = yargs
   .describe(args.PRETTY, 'pretty print the translation output')
   .describe(args.HELP, 'Display usage message')
   .alias(args.HELP, 'help')
-  .string(args.SPLIT_BY_LOCALE_TO)
-  .default(args.SPLIT_BY_LOCALE_TO, null)
+  .string(args.OUTPUT_DIR)
+  .default(args.OUTPUT_DIR, null)
+  .alias(args.OUTPUT_DIR, 'o')
   .describe(
-    args.SPLIT_BY_LOCALE_TO,
+    args.OUTPUT_DIR,
     'By default, we write the output to stdout. If you instead would like to split ' +
       'the output by locale you can use this arg to specify an output directory. ' +
       'This is useful when you want to lazy load translations per locale.',
@@ -220,16 +221,16 @@ const output = argv[args.STDIN]
   : processFiles(argv[args.SRC], argv[args.TRANSLATIONS]);
 
 function createJSON(obj) {
-  return JSON.stringify(obj, ...(argv[args.PRETTY] ? [null, ' '] : []));
+  return JSON.stringify(obj, ...(argv[args.PRETTY] ? [null, 2] : []));
 }
 
-const splitByLocaleTo = yargs.argv[args.SPLIT_BY_LOCALE_TO];
-if (splitByLocaleTo) {
-  fs.mkdirSync(splitByLocaleTo, {recursive: true});
+const outputDir = yargs.argv[args.OUTPUT_DIR];
+if (outputDir) {
+  fs.mkdirSync(outputDir, {recursive: true});
 
-  Object.keys(output).forEach(function(locale) {
+  Object.keys(output).forEach(locale => {
     fs.writeFileSync(
-      path.join(splitByLocaleTo, `${locale}.json`),
+      path.join(outputDir, `${locale}.json`),
       createJSON({[locale]: output[locale]}),
     );
   });


### PR DESCRIPTION
This PR adds the functionality to `translate.js` to split the translations into separate files based on local. The arg to do so is called 'split-by-locale-to', and I'm open for suggestions on the naming of the arg. This functionality will reduce the manual work of code splitting / lazy load translations based on locale. 

The PR was based on the discussions in [this](https://github.com/facebookincubator/fbt/issues/71) issue. However, the implementation differs a bit from the solution presented [here](https://github.com/facebookincubator/fbt/issues/71#issuecomment-525994553). The reason for the difference is that `translate.js` outputs default to stdout, which would be messy to deal with when we want to output to several files. The solution [here](https://github.com/facebookincubator/fbt/issues/71#issuecomment-525994553) could have been used if a new script was created, however in my opinion it seems like a better option to add an arg instead to the existing script. 

NOTE: I'm probably overseeing something, but I was not able to run any linter or any tests for the project before the commit. Seems like there are no eslint config? And there are only test scripts and a jest config added for the demo app? 