### PR TITLE
Ignoreing tests and mocks from babel plugins

### DIFF
--- a/transform/babel-plugin-fbt-runtime/.npmignore
+++ b/transform/babel-plugin-fbt-runtime/.npmignore
@@ -1,0 +1,4 @@
+# Since .gitignore is not considered when .npmignore is present
+node_modules
+
+__tests__

--- a/transform/babel-plugin-fbt/.npmignore
+++ b/transform/babel-plugin-fbt/.npmignore
@@ -1,0 +1,7 @@
+# Since .gitignore is not considered when .npmignore is present
+node_modules
+
+translate/__tests__
+bin/__tests__
+__mocks__
+__tests__


### PR DESCRIPTION
Added .npmignore file to exclude tests and mocks from package which is published. 

Ref: [https://github.com/facebookincubator/fbt/issues/80]