### PR TITLE
Support short locale format like 'ru',' zza'

### DIFF
--- a/runtime/nonfb/FBLocaleToLang.js
+++ b/runtime/nonfb/FBLocaleToLang.js
@@ -52,8 +52,13 @@ const _locToLang = {
 
 const FBLocaleToLang = {
   get: function(locale) {
-    return _locToLang[locale] || locale.substring(0, locale.indexOf('_'));
-  },
+    const lodashIndex = locale.indexOf("_");
+
+    return (
+      _locToLang[locale] ||
+      (lodashIndex !== -1 ? locale.substring(0, lodashIndex) : locale)
+    );
+  }
 };
 
 module.exports = FBLocaleToLang;


### PR DESCRIPTION
via: https://github.com/facebookincubator/fbt/issues/83

```js
var locale = 'ru';

fbt._prama(...)
   => getNumberVariations(...)
      => IntlNumberType.get(locale)    // Always return default value `IntlCLDRNumberType01`
         => FBLocaleToLang.get(locale) // Because result here is an empty string ''

FBLocaleToLang.get('ru') => ''
FBLocaleToLang.get('zza') => ''
```

