### PR TITLE
chore: Add Travis CI and fix references to old `transform` paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: node_js
+
+node_js:
+  - '10.4.0'
+  - '12'
+env:
+  - CMD=demo-app:test
+  - CMD=fb-tiger-hash:test
+  - CMD=babel-plugin-fbt-runtime:test
+  - CMD=babel-plugin-fbt:test
+
+branches:
+  only:
+    - master
+
+script: yarn run $CMD
+
+before_install:
+  # Install latest yarn (will go to ~/.yarn) and update $PATH for current shell
+  - curl -o- -L https:/yarnpkg.com/install.sh | bash
+  - export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,14 @@
   <img src="https://facebookincubator.github.io/fbt/img/fbt.png" height="150" width="150"/>
 </h1>
 
-FBT is an internationalization framework for JavaScript designed to be not just powerful and flexible, but also simple and intuitive.  It helps with the following:
+<h2 align="center">
+  <a href="https:/travis-ci.com/facebookincubator/fbt">
+    <img src="https:/travis-ci.com/facebookincubator/fbt.svg?branch=master" />
+  </a>
+</h2>
+
+FBT is an internationalization framework for JavaScript designed to be not just **powerful** and **flexible**, but also **simple** and **intuitive**.  It helps with the following:
+
 * Organizing your source text for translation
 * Composing grammatically correct translatable UI
 * Eliminating verbose boilerplate for generating UI

--- a/docs/collection.md
+++ b/docs/collection.md
@@ -4,7 +4,7 @@ title: Extracting FBTs
 sidebar_label: Extracting translatable texts
 ---
 We provide
-[`collectFbt.js`](https://github.com/facebookincubator/fbt/blob/master/transform/babel-plugin-fbt/bin/collectFBT.js)
+[`collectFbt.js`](https://github.com/facebookincubator/fbt/blob/master/packages/babel-plugin-fbt/bin/collectFBT.js)
 as a utility for collecting strings.  It expects a JSON input of:
 ```
 {

--- a/docs/translating.md
+++ b/docs/translating.md
@@ -4,7 +4,7 @@ title: Translating
 sidebar_label: Translating FBTs
 ---
 
-The [`translate`](https://github.com/facebookincubator/fbt/blob/master/transform/babel-plugin-fbt/bin/translate.js) script expects a JSON payload coming in from `STDIN`
+The [`translate`](https://github.com/facebookincubator/fbt/blob/master/packages/babel-plugin-fbt/bin/translate.js) script expects a JSON payload coming in from `STDIN`
 that has FBT `phrases` (just like those collected from `collectFbt`)
 alongside the relevant translations for a given locale.
 

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "postinstall": "yarn build-runtime",
     "demo-app:test": "yarn jest demo-app",
     "fb-tiger-hash:test": "yarn jest fb-tiger-hash",
-    "babel-plugin-fbt-runtime:test": "yarn jest transform/babel-plugin-fbt-runtime",
-    "babel-plugin-fbt:test": "yarn jest transform/babel-plugin-fbt",
+    "babel-plugin-fbt-runtime:test": "yarn jest packages/babel-plugin-fbt-runtime",
+    "babel-plugin-fbt:test": "yarn jest packages/babel-plugin-fbt",
     "test": "yarn jest"
   },
   "workspaces": [


### PR DESCRIPTION
This does the following
 * Patches `README.md` such that our internal tool for syncing repos is happy (they got out-of-sync)
 * Adds Travis CI support
  * Fixes some references in docs that were pointing to `transform/...` paths