### PR TITLE
chore: remove `fbt-rn-android-native` from yarn workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,11 @@
   "workspaces": [
     "demo-app",
     "live-demo-app",
-    "packages/*"
+    "packages/babel-plugin-fbt",
+    "packages/babel-plugin-fbt-runtime",
+    "packages/fb-babel-plugin-utils",
+    "packages/fb-tiger-hash",
+    "packages/fbt"
   ],
   "engines": {
     "node": ">= 10.4.0"


### PR DESCRIPTION
Original commit:
We didn't need to add this as a workspace.  We implicitly did so in our glob rule.

Shipit:
The internal and external repositories are out of sync. This attempts to brings them back in sync by patching the GitHub repository. Please carefully review this patch. You must disable ShipIt for your project in order to merge this pull request. DO NOT IMPORT this pull request. Instead, merge it directly on GitHub using the MERGE BUTTON. Re-enable ShipIt after merging.