### PR TITLE
Remove `@fbtjs/default-collection-transform` as a peer dep from `babel-plugin-fbt`.

### DIFF
--- a/packages/babel-plugin-fbt/package.json
+++ b/packages/babel-plugin-fbt/package.json
@@ -51,8 +51,5 @@
     "prepack": "gulp --series clean build",
     "publish_to_npm_latest": "yarn publish . && git push --tags && git push",
     "watch": "gulp watch"
-  },
-  "peerDependencies": {
-    "@fbtjs/default-collection-transform": "^1.0.0"
   }
 }


### PR DESCRIPTION
## Summary

The default collection transform is an example, and does not need to be used directly. In my case, I have my own collection transform and it doesn't make sense for package manager to suggest installing the default collection transform in such cases. I suggest removing it as a peer dep.

## Test plan

yolo